### PR TITLE
TFP-6047: Tillatter ikke tom på periode å være null (bruker heller 99…

### DIFF
--- a/domenetjenester/src/main/java/no/nav/folketrygdloven/kalkulus/domene/entiteter/beregningsgrunnlag/BeregningsgrunnlagPeriodeEntitet.java
+++ b/domenetjenester/src/main/java/no/nav/folketrygdloven/kalkulus/domene/entiteter/beregningsgrunnlag/BeregningsgrunnlagPeriodeEntitet.java
@@ -59,8 +59,8 @@ public class BeregningsgrunnlagPeriodeEntitet extends BaseEntitet {
     private final List<BeregningsgrunnlagAndelEntitet> beregningsgrunnlagAndelList = new ArrayList<>();
 
     @Embedded
-    @AttributeOverride(name = "fomDato", column = @Column(name = "periode_fom"))
-    @AttributeOverride(name = "tomDato", column = @Column(name = "periode_tom"))
+    @AttributeOverride(name = "fomDato", column = @Column(name = "periode_fom", nullable = false))
+    @AttributeOverride(name = "tomDato", column = @Column(name = "periode_tom", nullable = false))
     private IntervallEntitet periode;
 
     @Embedded

--- a/migreringer/src/main/resources/db/migration/defaultDS/1.0/V1.0.02__periode_tom_constraint.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/1.0/V1.0.02__periode_tom_constraint.sql
@@ -1,0 +1,1 @@
+alter table beregningsgrunnlag_periode alter column periode_tom set not null;


### PR DESCRIPTION
…99-12-31), slik det har vært i fpsak etter 2020.